### PR TITLE
Allow multiple commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
+.DS_Store
 node_modules

--- a/bin/vigilia
+++ b/bin/vigilia
@@ -12,7 +12,7 @@ var help,
     vigiliae = [ ];
 
 help = function() {
-  var man = spawn('man', ['man/vigilia.1'], {
+  spawn('man', ['man/vigilia.1'], {
     detached: true,
     stdio: 'inherit'
   });

--- a/lib/vigilia.js
+++ b/lib/vigilia.js
@@ -5,13 +5,7 @@ var debounce = require('debounce'),
     Vigilia;
 
 run = function(event, filepath) {
-  var options,
-      pattern = /^([^ ]+)\s*(.*)$/;
-
-  command = this.command.replace(pattern, '$1');
-  options = this.command.replace(pattern, '$2');
-
-  spawn(command, [options], {
+  spawn('sh', ['-c', this.command], {
     stdio: 'inherit'
   });
 };

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "debounce": "^1.0.0",
-    "gaze": "~0.5.1",
-    "shell-escape": "^0.1.0"
+    "gaze": "~0.5.1"
   },
   "description": "simple command line tool to watch and trigger multiple combinations of paths and commands",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "debounce": "^1.0.0",
-    "gaze": "~0.5.1"
+    "gaze": "~0.5.1",
+    "shell-escape": "^0.1.0"
   },
   "description": "simple command line tool to watch and trigger multiple combinations of paths and commands",
   "devDependencies": {

--- a/test/vigilia.js
+++ b/test/vigilia.js
@@ -40,8 +40,8 @@ describe("vigilia", function() {
     };
 
     spawn = function(command, args, options) {
-      expect(command).toBe('command');
-      expect(args).toEqual(['option']);
+      expect(command).toBe('sh');
+      expect(args).toEqual(['-c', 'command option']);
 
       done();
     };


### PR DESCRIPTION
made possible to pass complex commands to Vigilia, for example:

```sh
vigilia '*':'NOW_FILE=`date '+%Y-%m-%d-%H-%M-%S'`.log; touch $NOW_FILE; echo "created $NOW_FILE file"'
```

this will create an empty log file with the current date and time as name anytime some file changes, I know, I couldn't think of a better example.

resolves #2.